### PR TITLE
feat: upgrade urllib to 4.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22, 23]
+        node-version: [18, 20, 22, 23]
         os: [ubuntu-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ms": "^2.1.3",
     "oss-interface": "^1.3.0",
     "stream-wormhole": "^2.0.0",
-    "urllib": "^3.19.2",
+    "urllib": "^4.6.2",
     "utility": "^2.1.0",
     "xml2js": "^0.6.2"
   },

--- a/test/OSSObject.test.ts
+++ b/test/OSSObject.test.ts
@@ -53,7 +53,10 @@ describe('test/OSSObject.test.ts', () => {
     }
 
     it('should list with query', async () => {
-      const result = await ossObject.list();
+      const result = await ossObject.list({
+        prefix: listPrefix,
+        'max-keys': 5,
+      });
       assert(result.objects.length > 0);
       // console.log(result.objects);
       result.objects.map(checkObjectProperties);
@@ -1728,8 +1731,8 @@ describe('test/OSSObject.test.ts', () => {
   describe('copy()', () => {
     let name: string;
     let resHeaders: IncomingHttpHeaders;
-    let otherBucket: string;
-    let otherBucketObject: string;
+    // let otherBucket: string;
+    // let otherBucketObject: string;
     before(async () => {
       name = `${prefix}oss-client/oss/copy-meta.js`;
       const object = await ossObject.put(name, __filename, {
@@ -1783,25 +1786,25 @@ describe('test/OSSObject.test.ts', () => {
       assert.strictEqual(res.headers['content-disposition'], disposition);
     });
 
-    it.skip('should copy object from other bucket, sourceBucket in copySource', async () => {
-      const copySource = `/${otherBucket}/${otherBucketObject}`;
-      const copyTarget = `${prefix}oss-client/oss/copy-target.js`;
-      const result = await ossObject.copy(copyTarget, copySource);
-      assert.equal(result.res.status, 200);
+    // it.skip('should copy object from other bucket, sourceBucket in copySource', async () => {
+    //   const copySource = `/${otherBucket}/${otherBucketObject}`;
+    //   const copyTarget = `${prefix}oss-client/oss/copy-target.js`;
+    //   const result = await ossObject.copy(copyTarget, copySource);
+    //   assert.equal(result.res.status, 200);
+    //
+    //   const info = await ossObject.head(copyTarget);
+    //   assert.equal(info.status, 200);
+    // });
 
-      const info = await ossObject.head(copyTarget);
-      assert.equal(info.status, 200);
-    });
-
-    it.skip('should copy object from other bucket, sourceBucket is a separate parameter', async () => {
-      const copySource = otherBucketObject;
-      const copyTarget = `${prefix}oss-client/oss/has-bucket-name-copy-target.js`;
-      const result = await ossObject.copy(copyTarget, copySource, otherBucket);
-      assert.equal(result.res.status, 200);
-
-      const info = await ossObject.head(copyTarget);
-      assert.equal(info.status, 200);
-    });
+    // it.skip('should copy object from other bucket, sourceBucket is a separate parameter', async () => {
+    //   const copySource = otherBucketObject;
+    //   const copyTarget = `${prefix}oss-client/oss/has-bucket-name-copy-target.js`;
+    //   const result = await ossObject.copy(copyTarget, copySource, otherBucket);
+    //   assert.equal(result.res.status, 200);
+    //
+    //   const info = await ossObject.head(copyTarget);
+    //   assert.equal(info.status, 200);
+    // });
 
     it('should copy object with non-english name', async () => {
       const sourceName = `${prefix}oss-client/oss/copy-meta_测试.js`;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded `urllib` dependency to version 4.6.2.

- **Chores**
	- Adjusted CI workflow to remove Node.js version 16 from testing matrix, focusing on versions 18, 20, 22, and 23.

- **Tests**
	- Modified test suite for `OSSObject` class, focusing on the `copy()` method and maintaining core functionality checks, including tests for non-English names and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->