### PR TITLE
fix: patch File to support test on Node.js 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   release:
-    name: Node.js
-    uses: node-modules/github-actions/.github/workflows/node-release.yml@master
+    name: NPM
+    uses: node-modules/github-actions/.github/workflows/npm-release.yml@master
     secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ test/node/.tmp
 test/demo.js
 yarn.lock
 package-lock.json
+pnpm-lock.yaml
 .nyc_output/
 .env
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,12 +2,17 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "extends": ["./node_modules/@eggjs/oxlint-config/.oxlintrc.json"],
   "env": {
-    "node": true,
-    "mocha": true
+    "node": true
   },
   "rules": {
     "no-console": "warn",
     "no-empty-function": "allow"
   },
-  "ignorePatterns": ["index.d.ts", "test/fixtures/**", "__snapshots__"]
+  "ignorePatterns": [
+    "index.d.ts",
+    "test/fixtures/**",
+    "__snapshots__",
+    "test/*.cjs",
+    "test/setup.ts"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "lint": "oxlint",
     "pretest": "npm run lint -- --fix",
     "test": "vitest run --test-timeout 15000",
+    "test:cjs": "node test/hello.cjs",
     "cov": "npm run test -- --coverage",
     "preci": "npm run lint",
-    "ci": "npm run cov && npm run prepublishOnly && attw --pack",
+    "ci": "npm run cov && npm run prepublishOnly && attw --pack && npm run test:cjs",
     "prepublishOnly": "tshy && tshy-after",
     "prepare": "husky"
   },
@@ -43,27 +44,27 @@
     "ms": "^2.1.3",
     "oss-interface": "^1.3.0",
     "stream-wormhole": "^2.0.0",
-    "urllib": "^4.6.2",
+    "urllib": "^4.8.1",
     "utility": "^2.1.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.15.3",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@eggjs/oxlint-config": "^1.0.0",
     "@eggjs/tsconfig": "^1.1.0",
     "@types/mime": "^3.0.1",
-    "@types/ms": "^0.7.31",
-    "@types/node": "^20.3.1",
+    "@types/ms": "^0.7.34",
+    "@types/node": "^20.19.10",
     "@types/xml2js": "^0.4.12",
     "@vitest/coverage-v8": "^3.1.3",
     "husky": "^9.1.7",
-    "oxlint": "^0.16.10",
+    "oxlint": "^1.11.0",
     "prettier": "^3.5.3",
-    "read-env-value": "^1.0.1",
-    "tshy": "^1.0.0",
+    "read-env-value": "^1.1.0",
+    "tshy": "^1.18.0",
     "tshy-after": "^1.0.0",
     "typescript": "^5.2.2",
-    "vitest": "^3.1.3"
+    "vitest": "^3.2.4"
   },
   "files": [
     "dist",
@@ -92,5 +93,6 @@
     }
   },
   "types": "./dist/commonjs/index.d.ts",
-  "main": "./dist/commonjs/index.js"
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "husky": "^9.1.7",
     "oxlint": "^1.11.0",
     "prettier": "^3.5.3",
-    "read-env-value": "^1.1.0",
+    "read-env-value": "^2.0.2",
     "tshy": "^1.18.0",
     "tshy-after": "^1.0.0",
     "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -49,19 +49,19 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.15.4",
+    "@arethetypeswrong/cli": "^0.18.2",
     "@eggjs/oxlint-config": "^1.0.0",
     "@eggjs/tsconfig": "^1.1.0",
     "@types/mime": "^3.0.1",
     "@types/ms": "^0.7.34",
-    "@types/node": "^20.19.10",
+    "@types/node": "^24.2.1",
     "@types/xml2js": "^0.4.12",
     "@vitest/coverage-v8": "^3.1.3",
     "husky": "^9.1.7",
     "oxlint": "^1.11.0",
     "prettier": "^3.5.3",
     "read-env-value": "^2.0.2",
-    "tshy": "^1.18.0",
+    "tshy": "^3.0.2",
     "tshy-after": "^1.0.0",
     "typescript": "^5.2.2",
     "vitest": "^3.2.4"
@@ -81,12 +81,10 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
-        "source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "source": "./src/index.ts",
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }

--- a/src/util/sign.ts
+++ b/src/util/sign.ts
@@ -10,6 +10,15 @@ import { encodeCallback } from './encodeCallback.js';
 const debug = debuglog('oss-client:sign');
 const OSS_PREFIX = 'x-oss-';
 
+function compareCanonicalizedString(entry1: string, entry2: string) {
+  if (entry1[0] > entry2[0]) {
+    return 1;
+  } else if (entry1[0] < entry2[0]) {
+    return -1;
+  }
+  return 0;
+}
+
 /**
  * build canonicalized resource
  * @see https://help.aliyun.com/zh/oss/developer-reference/include-signatures-in-the-authorization-header#section-rvv-dx2-xdb
@@ -29,14 +38,6 @@ function buildCanonicalizedResource(
     parameters.sort();
     canonicalizedResource += separatorString + parameters.join('&');
   } else if (parameters) {
-    const compareFunc = (entry1: string, entry2: string) => {
-      if (entry1[0] > entry2[0]) {
-        return 1;
-      } else if (entry1[0] < entry2[0]) {
-        return -1;
-      }
-      return 0;
-    };
     const processFunc = (key: string) => {
       canonicalizedResource += separatorString + key;
       if (parameters[key] || parameters[key] === 0) {
@@ -44,7 +45,9 @@ function buildCanonicalizedResource(
       }
       separatorString = '&';
     };
-    for (const key of Object.keys(parameters).sort(compareFunc)) {
+    for (const key of Object.keys(parameters).sort(
+      compareCanonicalizedString
+    )) {
       processFunc(key);
     }
   }

--- a/test/hello.cjs
+++ b/test/hello.cjs
@@ -1,0 +1,11 @@
+const { OSSObject } = require('..');
+
+const ossObject = new OSSObject({
+  region: 'oss-cn-hangzhou',
+  endpoint: 'https://oss-cn-hangzhou.aliyuncs.com',
+  accessKeyId: 'LTAI5tG666666666666666',
+  accessKeySecret: '66666666666666666666666666666666',
+  bucket: 'foo',
+});
+
+console.log(ossObject);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,7 @@
+import { File } from 'node:buffer';
+
+// multi undici version in node version less than 20 https://github.com/nodejs/undici/issues/4374
+if (typeof global.File === 'undefined') {
+  // @ts-ignore
+  global.File = File;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['test/setup.ts'],
+  },
+});


### PR DESCRIPTION
also use npm trusted publisher https://github.com/node-modules/github-actions/issues/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new test script for CommonJS compatibility.
  * Introduced a setup file to ensure consistent global environment for tests.
  * Added a Vite configuration file for improved test setup.

* **Chores**
  * Updated dependencies to newer versions.
  * Enhanced .gitignore to exclude pnpm lock files.
  * Updated environment and ignore patterns in linting configuration.
  * Modified release workflow configuration for improved automation.
  * Added a module field in package configuration for ES module support.

* **Tests**
  * Improved test environment setup and added a basic instantiation test for the main class.
  * Adjusted a large file streaming test to skip on Node.js 18 due to timeout issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->